### PR TITLE
Allow for skipping of db operations during installation

### DIFF
--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -21,25 +21,30 @@ else
     composer --working-dir=$MAGENTO_ROOT install
 fi
 
-echo "Install Magento"
-
 chown -R www-data:www-data $MAGENTO_ROOT
 
-$MAGENTO_COMMAND setup:install \
-  --db-host=$M2SETUP_DB_HOST \
-  --db-name=$M2SETUP_DB_NAME \
-  --db-user=$M2SETUP_DB_USER \
-  --db-password=$M2SETUP_DB_PASSWORD \
-  --base-url=$M2SETUP_BASE_URL \
-  --backend-frontname=$M2SETUP_BACKEND_FRONTNAME \
-  --admin-firstname=$M2SETUP_ADMIN_FIRSTNAME \
-  --admin-lastname=$M2SETUP_ADMIN_LASTNAME \
-  --admin-email=$M2SETUP_ADMIN_EMAIL \
-  --admin-user=$M2SETUP_ADMIN_USER \
-  --admin-password=$M2SETUP_ADMIN_PASSWORD
+if [ ! "$M2SETUP_INSTALL_DB" = "false" ]; then
 
-$MAGENTO_COMMAND index:reindex
-$MAGENTO_COMMAND setup:static-content:deploy
+    echo "Install Magento"
+
+    $MAGENTO_COMMAND setup:install \
+      --db-host=$M2SETUP_DB_HOST \
+      --db-name=$M2SETUP_DB_NAME \
+      --db-user=$M2SETUP_DB_USER \
+      --db-password=$M2SETUP_DB_PASSWORD \
+      --base-url=$M2SETUP_BASE_URL \
+      --backend-frontname=$M2SETUP_BACKEND_FRONTNAME \
+      --admin-firstname=$M2SETUP_ADMIN_FIRSTNAME \
+      --admin-lastname=$M2SETUP_ADMIN_LASTNAME \
+      --admin-email=$M2SETUP_ADMIN_EMAIL \
+      --admin-user=$M2SETUP_ADMIN_USER \
+      --admin-password=$M2SETUP_ADMIN_PASSWORD
+
+    $MAGENTO_COMMAND index:reindex
+    $MAGENTO_COMMAND setup:static-content:deploy
+else
+    echo "Skipping DB installation"
+fi
 
 echo "Fixing file permissions.."
 

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -52,6 +52,7 @@ services:
       - ./global.env
       - ./composer.env
     environment:
+      - M2SETUP_INSTALL_DB=true
       - M2SETUP_DB_HOST=db
       - M2SETUP_DB_NAME=magento2
       - M2SETUP_DB_USER=magento2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ./global.env
       - ./composer.env
     environment:
+      - M2SETUP_INSTALL_DB=true
       - M2SETUP_DB_HOST=db
       - M2SETUP_DB_NAME=magento2
       - M2SETUP_DB_USER=magento2


### PR DESCRIPTION
The installation of the db will only not happen if the value of M2SETUP_INSTALL_DB is set to false.  This is for backwards compat.