### PR TITLE
Make $M2SETUP_BACKEND_FRONTNAME optional

### DIFF
--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -31,19 +31,24 @@ if [ ! "$M2SETUP_INSTALL_DB" = "false" ]; then
 
     echo "Install Magento"
 
-    $MAGENTO_COMMAND setup:install \
-      --db-host=$M2SETUP_DB_HOST \
-      --db-name=$M2SETUP_DB_NAME \
-      --db-user=$M2SETUP_DB_USER \
-      --db-password=$M2SETUP_DB_PASSWORD \
-      --base-url=$M2SETUP_BASE_URL \
-      --backend-frontname=$M2SETUP_BACKEND_FRONTNAME \
-      --admin-firstname=$M2SETUP_ADMIN_FIRSTNAME \
-      --admin-lastname=$M2SETUP_ADMIN_LASTNAME \
-      --admin-email=$M2SETUP_ADMIN_EMAIL \
-      --admin-user=$M2SETUP_ADMIN_USER \
-      --admin-password=$M2SETUP_ADMIN_PASSWORD
+    INSTALL_COMMAND = "$MAGENTO_COMMAND setup:install \
+        --db-host=$M2SETUP_DB_HOST \
+        --db-name=$M2SETUP_DB_NAME \
+        --db-user=$M2SETUP_DB_USER \
+        --db-password=$M2SETUP_DB_PASSWORD \
+        --base-url=$M2SETUP_BASE_URL \
+        --admin-firstname=$M2SETUP_ADMIN_FIRSTNAME \
+        --admin-lastname=$M2SETUP_ADMIN_LASTNAME \
+        --admin-email=$M2SETUP_ADMIN_EMAIL \
+        --admin-user=$M2SETUP_ADMIN_USER \
+        --admin-password=$M2SETUP_ADMIN_PASSWORD"
 
+    # Only define a backend-frontname if the variable is set, or not empty.
+    if [ -z "$M2SETUP_BACKEND_FRONTNAME" ]; then
+        INSTALL_COMMAND = "$INSTALL_COMMAND --backend-frontname=$M2SETUP_BACKEND_FRONTNAME"
+    fi
+
+    $INSTALL_COMMAND
     $MAGENTO_COMMAND index:reindex
     $MAGENTO_COMMAND setup:static-content:deploy
 else


### PR DESCRIPTION
When omited, a generated backend frontname will be used instead.

Fixes #13