### PR TITLE
Use a deeper directory as the default Magento root

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -51,7 +51,7 @@ ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
 
 ENV PHP_MEMORY_LIMIT 2G
 ENV PHP_ENABLE_XDEBUG false
-ENV MAGENTO_ROOT /magento
+ENV MAGENTO_ROOT /var/www/magento
 ENV COMPOSER_GITHUB_TOKEN ""
 ENV COMPOSER_MAGENTO_USERNAME ""
 ENV COMPOSER_MAGENTO_PASSWORD ""

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -47,7 +47,7 @@ ADD etc/php-fpm.conf /usr/local/etc/
 
 ENV PHP_MEMORY_LIMIT 2G
 ENV PHP_ENABLE_XDEBUG false
-ENV MAGENTO_ROOT /magento
+ENV MAGENTO_ROOT /var/www/magento
 ENV MAGENTO_RUN_MODE developer
 ENV DEBUG false
 ENV UPDATE_UID_GID false

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A collection of Docker images for running Magento 2 through nginx and on the com
 Configuration is driven through environment variables.  A comprehensive list of the environment variables used can be found in each `Dockerfile` and the commands in each `bin/` directory.
 
 * `PHP_MEMORY_LIMIT` - The memory limit to be set in the `php.ini`
-* `MAGENTO_ROOT` - The directory to which Magento should be installed
 * `MAGENTO_RUN_MODE` - Valid values, as defined in `Magento\Framework\App\State`: `developer`, `production`, `default`.
+* `MAGENTO_ROOT` - The directory to which Magento should be installed (defaults to `/var/www/magento`)
 * `COMPOSER_GITHUB_TOKEN` - Your [GitHub OAuth token](https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens), should it be needed
 * `COMPOSER_MAGENTO_USERNAME` - Your Magento Connect public authentication key ([how to get](http://devdocs.magento.com/guides/v2.0/install-gde/prereq/connect-auth.html))
 * `COMPOSER_MAGENTO_PASSWORD` - Your Magento Connect private authentication key

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -70,7 +70,7 @@ services:
   appdata:
     image: tianon/true
     volumes:
-      - ./magento:/magento
+      - ./magento:/var/www/magento
 
   dbdata:
     image: tianon/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
   appdata:
     image: tianon/true
     volumes:
-      - ./magento:/magento
+      - ./magento:/var/www/magento
 
   dbdata:
     image: tianon/true

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -8,7 +8,7 @@ ADD bin/* /usr/local/bin/
 ENV FPM_HOST fpm
 ENV FPM_PORT 9000
 ENV VIRTUAL_HOST magento.docker
-ENV MAGENTO_ROOT /magento
+ENV MAGENTO_ROOT /var/www/magento
 ENV MAGENTO_RUN_MODE developer
 ENV DEBUG false
 


### PR DESCRIPTION
Related: https://github.com/magento/magento2/issues/4784

We can't use `/magento` because we now get broken autoloader files from composer.