### PR TITLE
Increase fastcgi buffer size

### DIFF
--- a/nginx/etc/vhost.conf
+++ b/nginx/etc/vhost.conf
@@ -11,7 +11,7 @@ server {
 
     set $MAGE_ROOT !MAGENTO_ROOT!; # Variable: MAGENTO_ROOT
     set $MAGE_MODE !MAGENTO_RUN_MODE!; # Variable: MAGENTO_RUN_MODE
-    
+
     # Support for SSL termination.
     set $my_http "http";
     set $my_ssl "off";
@@ -149,13 +149,14 @@ server {
     location ~ (index|get|static|report|404|503)\.php$ {
         try_files $uri =404;
         fastcgi_pass   fastcgi_backend;
+        fastcgi_buffers 1024 4k;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
         fastcgi_param  PHP_VALUE "memory_limit=256M \n max_execution_time=600";
         fastcgi_read_timeout 600s;
         fastcgi_connect_timeout 600s;
         fastcgi_param  MAGE_MODE $MAGE_MODE;
-        
+
         # Magento uses the HTTPS env var to detrimine if it is using SSL or not.
         fastcgi_param  HTTPS $my_ssl;
 


### PR DESCRIPTION
This is the setting that is used in 2.1.x installations, and is sufficient for 502 errors where nginx receives a too large of a body.

Fixes #34