### PR TITLE
Don't define a VIRTUAL_HOST in the image

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,7 +7,6 @@ ADD bin/* /usr/local/bin/
 
 ENV FPM_HOST fpm
 ENV FPM_PORT 9000
-ENV VIRTUAL_HOST magento.docker
 ENV MAGENTO_ROOT /var/www/magento
 ENV MAGENTO_RUN_MODE developer
 ENV DEBUG false

--- a/nginx/bin/docker-environment
+++ b/nginx/bin/docker-environment
@@ -6,7 +6,6 @@ VHOST_FILE="/etc/nginx/conf.d/default.conf"
 
 [ ! -z "${FPM_HOST}" ] && sed -i "s/!FPM_HOST!/${FPM_HOST}/" $VHOST_FILE
 [ ! -z "${FPM_PORT}" ] && sed -i "s/!FPM_PORT!/${FPM_PORT}/" $VHOST_FILE
-[ ! -z "${VIRTUAL_HOST}" ] && sed -i "s/!VIRTUAL_HOST!/${VIRTUAL_HOST}/" $VHOST_FILE
 [ ! -z "${MAGENTO_ROOT}" ] && sed -i "s#!MAGENTO_ROOT!#${MAGENTO_ROOT}#" $VHOST_FILE
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" $VHOST_FILE
 

--- a/nginx/etc/vhost.conf
+++ b/nginx/etc/vhost.conf
@@ -7,7 +7,7 @@ upstream fastcgi_backend {
 server {
     listen 80;
 
-    server_name !VIRTUAL_HOST!; # Variable: VIRTUAL_HOST
+    server_name localhost;
 
     set $MAGE_ROOT !MAGENTO_ROOT!; # Variable: MAGENTO_ROOT
     set $MAGE_MODE !MAGENTO_RUN_MODE!; # Variable: MAGENTO_RUN_MODE


### PR DESCRIPTION
It's not guaranteed that the VIRTUAL_HOST environment variable will
need to be set on the www container; it could be on the varnish
container.

This causes a problem with the nginx-dockergen container (a common
usecase for running this container) whereby it could generate an
invalid configuration.

Closes #44.