### PR TITLE
Add wrapper for n98-magerun2.phar

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -47,7 +47,7 @@ RUN pecl install -o -f xdebug-2.4.0
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install n98-magerun2.phar and move to /usr/local/bin/
-RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && cp ./n98-magerun2.phar /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
 
 VOLUME /root/.composer/cache
 

--- a/7.0-cli/bin/magerun2
+++ b/7.0-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A number of commands are baked into the image and are available on the `$PATH`. 
 
 * `magento-command` - Provides a user-safe wrapper around the `bin/magento` command.
 * `magento-installer` - Installs and configures Magento into the directory defined in the `$MAGENTO_ROOT` environment variable.
-* `n98-magerun2.phar` - Is available, which provides a wider range of useful commands. [Learn more here](https://github.com/netz98/n98-magerun2)
+* `magerun2` - A user-safe wrapper for `n98-magerun2.phar`, which provides a wider range of useful commands. [Learn more here](https://github.com/netz98/n98-magerun2)
 
 It's recommended that you mount an external folder to `/root/.composer/cache`, otherwise you'll be waiting all day for Magento to download every time the container is booted.
 


### PR DESCRIPTION
- Use the www-data user
- Set the root directory to $MAGENTO_ROOT
- Update README

fixes #55