### PR TITLE
Fix Magento installed asking for Composer creds

### DIFF
--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -2,7 +2,7 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-AUTH_JSON_FILE="/root/.composer/auth.json"
+AUTH_JSON_FILE="$(composer -g config data-dir 2>/dev/null)/auth.json"
 
 if [ -f "$AUTH_JSON_FILE" ]; then
     # Get composer auth information into an environment variable to avoid "you need
@@ -20,6 +20,14 @@ if [ ! -f "$MAGENTO_ROOT/composer.json" ]; then
         magento/project-community-edition=$M2SETUP_VERSION \
         --no-interaction \
         $MAGENTO_ROOT
+
+    # Magento forces Composer to use $MAGENTO_ROOT/var/composer_home as the home directory
+    # when running any Composer commands through Magento, e.g. sampledata:deploy, so copy the
+    # credentials over to it to prevent Composer from asking for them again
+    if [ -f "$AUTH_JSON_FILE" ]; then
+        mkdir -p $MAGENTO_ROOT/var/composer_home
+        cp $AUTH_JSON_FILE $MAGENTO_ROOT/var/composer_home/auth.json
+    fi
 else
     echo "Magento installation found in $MAGENTO_ROOT, installing composer dependencies"
     composer --working-dir=$MAGENTO_ROOT install


### PR DESCRIPTION
Magento changes the Composer home directory to a new one inside the installation when running sampledata:deploy (https://github.com/magento/composer/blob/master/src/MagentoComposerApplication.php#L80). This prevents composer from using the configured credentials and fails non-interactive installations.

Fix by copying the credentials from the global configuration to the Magento Composer directory.