### PR TITLE
Use exec instead of spawning a new process and better argument pass through

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
     mysql-client \
     git \
     sendmail-bin \
-    sendmail
+    sendmail \
+    sudo
 
 # Configure the gd library
 RUN docker-php-ext-configure \

--- a/7.0-cli/bin/mageconfigsync
+++ b/7.0-cli/bin/mageconfigsync
@@ -2,4 +2,4 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-su www-data -s /bin/bash -c "mageconfigsync.phar --magento-root=$MAGENTO_ROOT $*"
+exec sudo -u www-data -- mageconfigsync.phar --magento-root=$MAGENTO_ROOT "$@"

--- a/7.0-cli/bin/magedbm2
+++ b/7.0-cli/bin/magedbm2
@@ -2,4 +2,4 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-su www-data -s /bin/bash -c "magedbm2.phar --root-dir=$MAGENTO_ROOT $*"
+exec sudo -u www-data -- magedbm2.phar --root-dir=$MAGENTO_ROOT "$@"

--- a/7.0-cli/bin/magento-command
+++ b/7.0-cli/bin/magento-command
@@ -5,4 +5,5 @@
 MAGENTO_COMMAND="$MAGENTO_ROOT/bin/magento"
 
 chmod +x $MAGENTO_COMMAND
-su -c "$MAGENTO_COMMAND $*" -s /bin/bash www-data
+
+exec sudo -u www-data -- $MAGENTO_COMMAND "$@"


### PR DESCRIPTION
Based on comments by @tgerulaitis on #73. Closes #75.

* Use `exec` to pass the execution into another binary instead of
  spawning a child process and waiting for it to resolve.

* Use `"$@"` here instead of `$*`. The latter expands parameters
  into a single quoted word, while the former expands them into
  separate quoted words (note the quotes around the `$@` too).

More info: https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html.