### PR TITLE
Increas client_max_body_size for Nginx

### DIFF
--- a/nginx/etc/vhost.conf
+++ b/nginx/etc/vhost.conf
@@ -31,6 +31,7 @@ server {
     index index.php;
     autoindex off;
     charset UTF-8;
+    client_max_body_size 10M;
     error_page 404 403 = /errors/404.php;
     #add_header "X-UA-Compatible" "IE=Edge";
 


### PR DESCRIPTION
The default value seems too small, the server throws Nginx Error - 413 Request Entity Too Large even on normal data.