### PR TITLE
Ensuring the executable permission 

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -74,6 +74,12 @@ ENV COMPOSER_BITBUCKET_SECRET ""
 ENV DEBUG false
 ENV UPDATE_UID_GID false
 
+RUN ["chmod", "+x", "/usr/local/bin/docker-environment"]
+RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
+RUN ["chmod", "+x", "/usr/local/bin/magento-command"]
+RUN ["chmod", "+x", "/usr/local/bin/magerun2"]
+RUN ["chmod", "+x", "/usr/local/bin/run-cron"]
+
 ENTRYPOINT ["/usr/local/bin/docker-environment"]
 
 CMD ["bash"]

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -55,5 +55,7 @@ ENV MAGENTO_RUN_MODE developer
 ENV DEBUG false
 ENV UPDATE_UID_GID false
 
+RUN ["chmod", "+x", "/usr/local/bin/docker-environment"]
+
 ENTRYPOINT ["/usr/local/bin/docker-environment"]
 CMD ["php-fpm", "-F"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -14,5 +14,7 @@ ENV MAGENTO_ROOT /var/www/magento
 ENV MAGENTO_RUN_MODE developer
 ENV DEBUG false
 
+RUN ["chmod", "+x", "/usr/local/bin/docker-environment"]
+
 ENTRYPOINT ["/usr/local/bin/docker-environment"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This makes the setup more robust as some automated build environments can strip the executable permission from the files that need it