### PR TITLE
Adding global.env to cron container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,8 @@ services:
     image: meanbee/magento2-php:7.1-cli
     hostname: magento2-cron.docker
     command: run-cron
+    env_file:
+      - ./global.env    
     environment:
       - ENABLE_SENDMAIL=true
     volumes_from:


### PR DESCRIPTION
As cli container is used for cron it should also use the global.env values as they are used in cli container. Otherwise this can cause unexpected results as UPDATE_UID_GID for example will not have the same value in cron container.