### PR TITLE
Recreate database from backup

### DIFF
--- a/db_backup.sh
+++ b/db_backup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec dockermagento2_db_1 /usr/bin/mysqldump -u magento2 --password=magento2 magento2 > backup.sql

--- a/db_restore.sh
+++ b/db_restore.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker-compose run cli magento-command setup:db-schema:upgrade
+
+cat backup.sql | docker exec -i dockermagento2_db_1 /usr/bin/mysql -u root --password=magento2 magento2


### PR DESCRIPTION
When containers are taken down (instead of stopped) the database will be removed. If there is a db backup created with the backup script it can be recreated with the restore script when the containers are running again. The backup/restore can be used to move the database to another host as well.