### PR TITLE
Install the bcmath php extension

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -37,7 +37,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
-  soap
+  soap \
+  bcmath
 
 # Install Xdebug (but don't enable)
 RUN pecl install -o -f xdebug

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -33,7 +33,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
-  soap
+  soap \
+  bcmath
 
 # Install Xdebug (but don't enable)
 RUN pecl install -o -f xdebug

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -37,7 +37,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
-  soap
+  soap \
+  bcmath
 
 # Install Xdebug (but don't enable)
 RUN pecl install -o -f xdebug

--- a/7.1-fpm/Dockerfile
+++ b/7.1-fpm/Dockerfile
@@ -33,7 +33,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
-  soap
+  soap \
+  bcmath
 
 # Install Xdebug (but don't enable)
 RUN pecl install -o -f xdebug

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -39,7 +39,8 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
-  soap
+  soap \
+  bcmath
 
 # Install Xdebug (but don't enable)
 RUN pecl install -o -f xdebug


### PR DESCRIPTION
Add the `bcmath` extension to the images. Looks like this was required with 2.2 but was not defined in any `composer.json` as a platform requirement. See: https://github.com/magento/magento2/pull/12768.