### PR TITLE
Skip static deployment for extensions

### DIFF
--- a/7.0-cli/bin/magento-extension-installer
+++ b/7.0-cli/bin/magento-extension-installer
@@ -292,7 +292,6 @@ class Magento_Extension_Installer
         return $this->magentoCommand("module:enable $name")
             && $this->magentoCommand("setup:upgrade")
             && $this->magentoCommand("setup:di:compile")
-            && $this->magentoCommand("setup:static-content:deploy")
             && $this->magentoCommand("cache:flush");
     }
 

--- a/7.1-cli/bin/magento-extension-installer
+++ b/7.1-cli/bin/magento-extension-installer
@@ -292,7 +292,6 @@ class Magento_Extension_Installer
         return $this->magentoCommand("module:enable $name")
             && $this->magentoCommand("setup:upgrade")
             && $this->magentoCommand("setup:di:compile")
-            && $this->magentoCommand("setup:static-content:deploy")
             && $this->magentoCommand("cache:flush");
     }
 

--- a/7.2-cli/bin/magento-extension-installer
+++ b/7.2-cli/bin/magento-extension-installer
@@ -292,7 +292,6 @@ class Magento_Extension_Installer
         return $this->magentoCommand("module:enable $name")
             && $this->magentoCommand("setup:upgrade")
             && $this->magentoCommand("setup:di:compile")
-            && $this->magentoCommand("setup:static-content:deploy")
             && $this->magentoCommand("cache:flush");
     }
 

--- a/src/bin/magento-extension-installer
+++ b/src/bin/magento-extension-installer
@@ -292,7 +292,6 @@ class Magento_Extension_Installer
         return $this->magentoCommand("module:enable $name")
             && $this->magentoCommand("setup:upgrade")
             && $this->magentoCommand("setup:di:compile")
-            && $this->magentoCommand("setup:static-content:deploy")
             && $this->magentoCommand("cache:flush");
     }
 


### PR DESCRIPTION
Fixing just what I need for 2.2 for now. There's quite a few things that we should change in `magento-installer` (#113) so I'll come back to it when I can dedicate a larger chunk of time.