### PR TITLE
Use the latest xdebug on 7.2 images

### DIFF
--- a/7.2-cli/Dockerfile
+++ b/7.2-cli/Dockerfile
@@ -41,7 +41,7 @@ RUN docker-php-ext-install \
   bcmath
 
 # Install Xdebug (but don't enable)
-RUN pecl install -o -f xdebug-2.6.0beta1
+RUN pecl install -o -f xdebug
 
 ENV PHP_MEMORY_LIMIT 2G
 ENV PHP_ENABLE_XDEBUG false

--- a/7.2-fpm/Dockerfile
+++ b/7.2-fpm/Dockerfile
@@ -37,7 +37,7 @@ RUN docker-php-ext-install \
   bcmath
 
 # Install Xdebug (but don't enable)
-RUN pecl install -o -f xdebug-2.6.0beta1
+RUN pecl install -o -f xdebug
 
 ENV PHP_MEMORY_LIMIT 2G
 ENV PHP_ENABLE_XDEBUG false

--- a/config.json
+++ b/config.json
@@ -140,7 +140,7 @@
       "etc/php-xdebug.ini": {}
     },
     "phpExtensions": [],
-    "xdebugVersion": "2.6.0beta1"
+    "xdebugVersion": "latest"
   },
   "7.2-fpm": {
     "version": "7.2",
@@ -156,6 +156,6 @@
       "etc/php-fpm.conf": {}
     },
     "phpExtensions": [],
-    "xdebugVersion": "2.6.0beta1"
+    "xdebugVersion": "latest"
   }
 }


### PR DESCRIPTION
IIRC we needed this beta version because it was the only one compatible with 7.2.