### PR TITLE
Mysql Client package name has changed to default-mysql-client

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     sudo \ 
     cron \ 
     rsyslog \ 
-    mysql-client \ 
+    default-mysql-client \
     git
 
 # Configure the gd library

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     sudo \ 
     cron \ 
     rsyslog \ 
-    mysql-client \ 
+    default-mysql-client \
     git
 
 # Configure the gd library

--- a/7.2-cli/Dockerfile
+++ b/7.2-cli/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     sudo \ 
     cron \ 
     rsyslog \ 
-    mysql-client \ 
+    default-mysql-client \
     git
 
 # Configure the gd library


### PR DESCRIPTION
When I try to rebuild my cli image, the package mysql-client was not found :

`docker build -t meanbee/magento2-php:7.2 7.2-cli/`
E: Package 'mysql-client' has no installation candidate

I have juste change the mysql client package name to default-mysql-client.

Regards,

Camille