### PR TITLE
Fix typos

### DIFF
--- a/7.0-cli/bin/magento-extension-installer
+++ b/7.0-cli/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/7.1-cli/bin/magento-extension-installer
+++ b/7.1-cli/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/7.2-cli/bin/magento-extension-installer
+++ b/7.2-cli/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/7.3-cli/bin/magento-extension-installer
+++ b/7.3-cli/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/7.4-cli/bin/magento-extension-installer
+++ b/7.4-cli/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configuration is driven through environment variables.  A comprehensive list of 
 * `COMPOSER_MAGENTO_PASSWORD` - Your Magento Connect private authentication key
 * `COMPOSER_BITBUCKET_KEY` - Optional - Your Bitbucket OAuth key ([how to get](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html))
 * `COMPOSER_BITBUCKET_SECRET` - Optional - Your Bitbucket OAuth secret
-* `DEBUG` - Toggles tracing in the bash commands when exectued; nothing to do with Magento`
+* `DEBUG` - Toggles tracing in the bash commands when executed; nothing to do with Magento`
 * `PHP_ENABLE_XDEBUG` - When set to `true` it will include the Xdebug ini file as part of the PHP configuration, turning it on. It's recommended to only switch this on when you need it as it will slow down the application.
 * `UPDATE_UID_GID` - If this is set to "true" then the uid and gid of `www-data` will be modified in the container to match the values on the mounted folders.  This seems to be necessary to work around virtualbox issues on OSX.
 

--- a/src/bin/magento-extension-installer
+++ b/src/bin/magento-extension-installer
@@ -396,7 +396,7 @@ MSG;
 
     /**
      * Output an informational message. Any additional parameters will be
-     * passed into a sprintf() along with the message before outputing it.
+     * passed into a sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters
@@ -408,7 +408,7 @@ MSG;
 
     /**
      * Output an error message. Any additional parameters will be passed into a
-     * sprintf() along with the message before outputing it.
+     * sprintf() along with the message before outputting it.
      *
      * @param string $message
      * @param array  ...$parameters

--- a/varnish/etc/varnish.vcl
+++ b/varnish/etc/varnish.vcl
@@ -63,7 +63,7 @@ sub vcl_recv {
         } elsif (req.http.Accept-Encoding ~ "deflate" && req.http.user-agent !~ "MSIE") {
             set req.http.Accept-Encoding = "deflate";
         } else {
-            # unkown algorithm
+            # unknown algorithm
             unset req.http.Accept-Encoding;
         }
     }


### PR DESCRIPTION
Hello,

This PR will fix : 

- 2 typos in `7.0-cli/bin/magento-extension-installer`
- 2 typos in `7.1-cli/bin/magento-extension-installer`
- 2 typos in `7.2-cli/bin/magento-extension-installer`
- 2 typos in `7.3-cli/bin/magento-extension-installer`
- 2 typos in `7.4-cli/bin/magento-extension-installer`
- 1 typo in `README.md`
- 2 typos in `src/bin/magento-extension-installer`
- 1 typo in `varnish/etc/varnish.vcl`



Cheers! :robot: