### PR TITLE
Install native 'zip' package on CLI images for quicker composer installs

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update \
     cron \ 
     rsyslog \ 
     mysql-client \ 
-    git
+    git \ 
+    zip
 
 # Configure the gd library
 RUN docker-php-ext-configure \

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update \
     cron \ 
     rsyslog \ 
     default-mysql-client \ 
-    git
+    git \ 
+    zip
 
 # Configure the gd library
 RUN docker-php-ext-configure \

--- a/7.2-cli/Dockerfile
+++ b/7.2-cli/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update \
     cron \ 
     rsyslog \ 
     default-mysql-client \ 
-    git
+    git \ 
+    zip
 
 # Configure the gd library
 RUN docker-php-ext-configure \

--- a/7.3-cli/Dockerfile
+++ b/7.3-cli/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     rsyslog \ 
     default-mysql-client \ 
     git \ 
+    zip \ 
     libzip-dev
 
 # Configure the gd library

--- a/7.4-cli/Dockerfile
+++ b/7.4-cli/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     rsyslog \ 
     default-mysql-client \ 
     git \ 
+    zip \ 
     libzip-dev \ 
     libonig-dev
 

--- a/src/Dockerfile-cli
+++ b/src/Dockerfile-cli
@@ -3,7 +3,8 @@ $imageSpecificPackages = [
     'cron',
     'rsyslog',
     (version_compare($version, '7.0', '<=') ? 'mysql-client' : 'default-mysql-client'),
-    'git'
+    'git',
+    'zip',
 ];
 
 include "Dockerfile";


### PR DESCRIPTION
Otherwise Composer will use PHP's ZIP library, which is a bit slower, may
cause invalid reports of corrupted archives, and causes UNIX permissions
in the archives to be lost.